### PR TITLE
Remove token do exemplo da chamada para o endpoint de Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Já que o endpoint da autenticação é [**<code>POST</code> api/v2/tokens**](v2
 
 ```
 curl "https://web.monde.com.br/api/v2/tokens" -d '{ "data": {"type": "tokens", "attributes": {"login": "admin@suagencia.monde.com.br","password": "u4K2EJwGFL" } } }' -X POST \
-	-H "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1aWQiOiI4MzJkMjFmMS02ZDU0LTQzMjItYWUyNS05M2NkNGJhNzQ5ZmYiLCJpc3N1ZXIiOiJNb25kZSIsInNjaGVtYSI6Im1vbmRlc2lzdGVtYXMiLCJleHAiOjE2MzU0NTM0MzR9.HVW91M7lSA07syCxPPdVJOSi8M7Z9nGQ5ZxPz-JyriA" \
 	-H "Accept: application/vnd.api+json" \
 	-H "Content-Type: application/vnd.api+json"
 ```


### PR DESCRIPTION
Removi o header "Authorization" do exemplo da chamada para o endpoint de aquisiçào de tokens. Não é necessário neste endpoint. 